### PR TITLE
Added mappings for timezones abbreviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## zc_common
 
 #### Installation
-Add `-e git+http://github.com/zerocater/zc_common.git@0.0.1#egg=zc_common` to your `requirements.txt`
+Add `-e git+http://github.com/zerocater/zc_common.git@0.0.2#egg=zc_common` to your `requirements.txt`
 
 #### Usage
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup
 
 setup(name='zc_common',
-      version='0.0.1',
+      version='0.0.2',
       description="A collection of Python utils",
       long_description='',
       keywords='zerocater python util',
       author='ZeroCater',
       author_email='tech@zerocater.com',
       url='https://github.com/ZeroCater/zc_common',
-      download_url='https://github.com/ZeroCater/zc_common/tarball/0.0.1',
+      download_url='https://github.com/ZeroCater/zc_common/tarball/0.0.2',
       license='MIT',
       packages=['zc_common'],
       classifiers=[

--- a/zc_common/timezone.py
+++ b/zc_common/timezone.py
@@ -115,6 +115,8 @@ def timezone_abbrv_mappings():
             'EST': gettz('America/New_York'),
             'CDT': gettz('America/Chicago'),
             'CST': gettz('America/Chicago'),
+            'MDT': gettz('America/Denver'),
+            'MST': gettz('America/Denver'),
             'PDT': gettz('America/Los_Angeles'),
             'PST': gettz('America/Los_Angeles')}
 

--- a/zc_common/timezone.py
+++ b/zc_common/timezone.py
@@ -105,6 +105,20 @@ def get_timezone_offset(value):
     return _get_datetime_from_ambiguous_value(value).strftime('%z')
 
 
+def timezone_abbrv_mappings():
+    """
+    By default, dateutil doesn't parse at least `EDT` correctly.
+    Pass output of this function as `tzinfos` param to parse() if it isn't pickin up timezone correctly.
+    """
+    from dateutil.tz import *
+    return {'EDT': gettz('America/New_York'),
+            'EST': gettz('America/New_York'),
+            'CDT': gettz('America/Chicago'),
+            'CST': gettz('America/Chicago'),
+            'PDT': gettz('America/Los_Angeles'),
+            'PST': gettz('America/Los_Angeles')}
+
+
 def _get_datetime_from_ambiguous_value(value):
     if type(value) is python_datetime.datetime:
         new_datetime = localtime(value, tz=value.tzinfo)
@@ -133,16 +147,8 @@ def parse(date_string, **kwargs):
     """ A wrapper around python-dateutil's parse function which ensures it always returns an aware datetime """
     from dateutil.parser import parse as datetime_parser
     from django.utils.timezone import is_aware, make_aware
-    from dateutil.tz import *
 
-    tzinfos = {'EDT': tzfile('/usr/share/zoneinfo/America/New_York'),
-               'EST': tzfile('/usr/share/zoneinfo/America/New_York'),
-               'CDT': tzfile('/usr/share/zoneinfo/America/Chicago'),
-               'CST': tzfile('/usr/share/zoneinfo/America/Chicago'),
-               'PDT': tzfile('/usr/share/zoneinfo/America/Los_Angeles'),
-               'PST': tzfile('/usr/share/zoneinfo/America/Los_Angeles')}
-
-    parsed = datetime_parser(date_string, tzinfos=tzinfos, **kwargs)
+    parsed = datetime_parser(date_string, **kwargs)
     # Make aware
     parsed = parsed if is_aware(parsed) else make_aware(parsed, _get_tz())
     # Ensure that we have the correct offset, while also keeping what was passed in.

--- a/zc_common/timezone.py
+++ b/zc_common/timezone.py
@@ -133,8 +133,16 @@ def parse(date_string, **kwargs):
     """ A wrapper around python-dateutil's parse function which ensures it always returns an aware datetime """
     from dateutil.parser import parse as datetime_parser
     from django.utils.timezone import is_aware, make_aware
+    from dateutil.tz import *
 
-    parsed = datetime_parser(date_string, **kwargs)
+    tzinfos = {'EDT': tzfile('/usr/share/zoneinfo/America/New_York'),
+               'EST': tzfile('/usr/share/zoneinfo/America/New_York'),
+               'CDT': tzfile('/usr/share/zoneinfo/America/Chicago'),
+               'CST': tzfile('/usr/share/zoneinfo/America/Chicago'),
+               'PDT': tzfile('/usr/share/zoneinfo/America/Los_Angeles'),
+               'PST': tzfile('/usr/share/zoneinfo/America/Los_Angeles')}
+
+    parsed = datetime_parser(date_string, tzinfos=tzinfos, **kwargs)
     # Make aware
     parsed = parsed if is_aware(parsed) else make_aware(parsed, _get_tz())
     # Ensure that we have the correct offset, while also keeping what was passed in.


### PR DESCRIPTION
### Problem:
Scheduled meal edit tool doesn't seem to work correctly when editing a meal for company in a different timezone.
Upon further investigation, the problem seem to in `dateutil` library.
Multiple people have reported problems parsing abbreviations like `EST`, `EDT`, and `CST`:
 - http://stackoverflow.com/a/1703591
 - https://github.com/dateutil/dateutil/issues/189

### Solution:
Make parsing rules for timezone abbreviations explicit, and pass them into the parser.

