### PR TITLE
Add jwt_auth package for JWT-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## zc_common
 
 #### Installation
-Add `-e git+http://github.com/zerocater/zc_common.git@0.1.1#egg=zc_common` to your `requirements.txt`
+Add `-e git+http://github.com/zerocater/zc_common.git@0.1.2#egg=zc_common` to your `requirements.txt`
 
 #### Usage
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_packages(package):
             if os.path.exists(os.path.join(dirpath, '__init__.py'))]
 
 setup(name='zc_common',
-      version='0.1.1',
+      version='0.1.2',
       description="A collection of Python utils",
       long_description='',
       keywords='zerocater python util',

--- a/zc_common/jwt_auth/README.md
+++ b/zc_common/jwt_auth/README.md
@@ -1,5 +1,8 @@
 # Service Authorization
 
+This document serves to explain how microservices can handle authorization of
+incoming requests.
+
 ## JWTs
 
 Example:

--- a/zc_common/jwt_auth/README.md
+++ b/zc_common/jwt_auth/README.md
@@ -1,0 +1,120 @@
+# Service Authorization
+
+## JWTs
+
+Example:
+```javascript
+{
+  "id": "356",
+  "roles": ["staff"]
+}
+```
+
+The mechanism for authorization is the JWT that will be provided with each
+authenticated request. This JWT contains details about the user, which services
+will need for the purposes of authorization.
+
+## Django Rest Framework
+
+### Authentication class
+
+A prerequisite to any permissions is the `JWTAuthentication` class. You'll
+need to include this class in your view's `authentication_classes` in order for
+any of the below permissions to function properly. The `JWTAuthentication` class
+assists by handling the decoding of incoming JWTs.
+
+First, install [`zc_common`](https://github.com/ZeroCater/zc_common) if you
+haven't already, along with `restframework_jwt`:
+```bash
+pip install djangorestframework_jwt
+```
+
+Next, import the `JWTAuthentication` class and include it.
+```python
+from zc_common.jwt_auth import JWTAuthentication
+
+class MyView(ApiView):
+  authentication_classes = (JWTAuthentication,)
+```
+
+### Permissions
+
+You'll usually need to write your own permissions, based on the needs of your
+view. But here are some example permissions to show you how:
+
+```python
+from django.contrib.auth.models import AnonymousUser
+from rest_framework.permissions import BasePermission
+
+
+class IsAuthenticated(BasePermission):
+  '''
+  A permission to verify the user is authenticated
+  '''
+  def has_permission(self, request, view):
+    return type(request.user) != AnonymousUser
+    
+    
+class IsStaff(BasePermission):
+  '''
+  A permission to verify the user is staff
+  '''
+  def has_permission(self, request, view):
+    return 'staff' in request.user['roles']
+    
+    
+class IsOrderOwner(BasePermission):
+  '''
+  A permission to verify the user is the author of the order.
+  '''
+  def has_object_permission(self, request, view, obj):
+    # In this case, `obj` is the Order instance
+    return request.user['id'] == obj.owner.id
+```
+
+Here's some example views to show how the permissions could be used:
+
+```python
+from rest_framework import generics
+from zc_common.jwt_auth import JWTAuthentication
+
+class MealDetailView(generics.RetrieveAPIView):
+  '''
+  A simple public view for viewing the details of a meal.
+  '''
+  
+  queryset = Meal.objects.all()
+
+
+class OrderDetailView(generics.RetrieveAPIView):
+  '''
+  A simple detail view that requires the user to be authenticated, and the
+  owner of the specific order.
+  '''
+  
+  # JWTAuthentication decodes the JWT and assigns the payload to `request.user`
+  authentication_classes = (JWTAuthentication,)
+  permission_classes = (IsAuthenticated, IsOrderOwner)
+  queryset = Order.objects.all()
+```
+
+## Authorization Explanations
+
+For implementing authorization outside of Django Rest Framework, follow these
+rules.
+
+### Public
+
+If a service wishes to make a route public, no work is required.
+
+### Authentication-required
+
+For routes which require the user to simply be logged in, services simply need
+to check for the presence of the JWT. The gateway validates any provided JWTs,
+and rejects those that are invalid, so if a service gets a request with a JWT,
+they can trust that it is valid, and that user is authenticated.
+
+### Staff Only
+
+Routes that are only accessible to staff will need to check the `roles`
+key of the JWT. Staff can be distinguished with the `staff` role.

--- a/zc_common/jwt_auth/__init__.py
+++ b/zc_common/jwt_auth/__init__.py
@@ -1,0 +1,1 @@
+from authentication import JWTAuthentication

--- a/zc_common/jwt_auth/authentication.py
+++ b/zc_common/jwt_auth/authentication.py
@@ -1,0 +1,79 @@
+import jwt
+from django.utils.encoding import smart_text
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication, get_authorization_header
+from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.utils import jwt_decode_handler
+
+
+class User(object):
+    '''
+    A class that emulates Django's auth User, for use with microservices where
+    the actual User is unavailable. Surfaces via `request.user`.
+    '''
+
+    def __init__(self, **kwargs):
+        for kwarg in kwargs:
+            setattr(self, kwarg, kwargs[kwarg])
+
+    def is_authenticated(self):
+        return True
+
+
+class JWTAuthentication(BaseAuthentication):
+    """
+        Clients should authenticate by passing the token key in the "Authorization"
+        HTTP header, prepended with the string specified in the setting
+        `JWT_AUTH_HEADER_PREFIX`. For example:
+
+            Authorization: JWT eyJhbGciOiAiSFMyNTYiLCAidHlwIj
+    """
+    www_authenticate_realm = 'api'
+
+    def get_jwt_value(self, request):
+        auth = get_authorization_header(request).split()
+        auth_header_prefix = api_settings.JWT_AUTH_HEADER_PREFIX.lower()
+
+        if not auth or smart_text(auth[0].lower()) != auth_header_prefix:
+            return None
+
+        if len(auth) == 1:  # pragma: no cover
+            msg = 'Invalid Authorization header. No credentials provided.'
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:  # pragma: no cover
+            msg = 'Invalid Authorization header. Credentials string should not contain spaces.'
+            raise exceptions.AuthenticationFailed(msg)
+
+        return auth[1]
+
+    def authenticate(self, request):
+        """
+        Returns a two-tuple of `User` and token if a valid signature has been
+        supplied using JWT-based authentication.  Otherwise returns `None`.
+        """
+        jwt_value = self.get_jwt_value(request)
+        if jwt_value is None:
+            return None
+
+        try:
+            payload = jwt_decode_handler(jwt_value)
+        except jwt.ExpiredSignature:  # pragma: no cover
+            msg = 'Signature has expired.'
+            raise exceptions.AuthenticationFailed(msg)
+        except jwt.DecodeError:  # pragma: no cover
+            msg = 'Error decoding signature.'
+            raise exceptions.AuthenticationFailed(msg)
+        except jwt.InvalidTokenError:  # pragma: no cover
+            raise exceptions.AuthenticationFailed()
+
+        user = User(**payload)
+
+        return (user, jwt_value)
+
+    def authenticate_header(self, request):
+        """
+            Return a string to be used as the value of the `WWW-Authenticate`
+            header in a `401 Unauthenticated` response, or `None` if the
+            authentication scheme should return `403 Permission Denied` responses.
+        """
+        return '{0} realm="{1}"'.format(api_settings.JWT_AUTH_HEADER_PREFIX, self.www_authenticate_realm)


### PR DESCRIPTION
Code and documentation necessary for implementing JWT-based authorization in Django Rest Framework microservices, when the `User` model is not local.

### View the document [here](https://github.com/ZeroCater/zc_common/blob/b09bb46f9c381e6a2d5fb555b927719a8ee412af/zc_common/jwt_auth/README.md)