### PR TITLE
amberylx/menu-blueprint-category-filter

### DIFF
--- a/zc_common/remote_resource/filters.py
+++ b/zc_common/remote_resource/filters.py
@@ -1,5 +1,6 @@
 import re
 
+from django.db.models.fields.related import ManyToManyField
 from rest_framework import filters
 
 
@@ -23,6 +24,8 @@ class JSONAPIFilterBackend(filters.DjangoFilterBackend):
                     return queryset.none()
                 if 'id' in field_name:
                     query_params['{0}__{1}'.format(primary_key, extra)] = value
+                if isinstance(getattr(queryset.model, field_name).field, ManyToManyField):
+                    value = value.split(',')
                 query_params[field_name] = value
 
         if filter_class:


### PR DESCRIPTION
This PR originated from a requirement on the location detail page to filter menus by category. Ideally, we would be able to get all menus at `/menu_blueprints`, and filter for a category by using a filter query param, e.g. `/menu_blueprints?filter[categories]=1`. Our existing support for filter query params allowed for filtering by `id` and other simple model attributes, but did not handle more complex attributes such as `categories`, which is a many-to-many relationship field.

After some digging into the `django-filters` library, it seemed that the above filter was being rejected because a many-to-many relationship filter was expecting a `list` value type instead of a `string`, e.g. it wants `[1]` instead of `'1'`.

This change will detect when the query param is filtering on a many-to-many attribute, and passes a `list` on to `django-filters`.

 `/menu_blueprints?filter[categories]=1,2` will actually filter all `MenuBlueprint`s with `categories.id` = `1` or `2`, along the lines of `MenuBlueprint.objects.filter(categories__in=[1,2])`.