### PR TITLE
Add support for relationships.<key>.links in RemoteResourceWrapper

### DIFF
--- a/tests/remote_resource/test_requests.py
+++ b/tests/remote_resource/test_requests.py
@@ -152,6 +152,35 @@ class WrappersTestCase(TestCase):
         self.assertEqual(resources[0].authors[0].type, 'People')
         self.assertEqual(resources[0].authors[0].id, '9')
 
+    def test_remote_resource_list_wrapper_multiple_relationship_links(self):
+        data = {
+            "data": [
+                {
+                    "type": "articles",
+                    "id": "1",
+                    "attributes": {
+                        "title": "Omakase"
+                    },
+                    "relationships": {
+                        "authors": {
+                            "links": {
+                                "self": "/articles/1/relationships/authors",
+                                "related": "/articles/1/authors"
+                            },
+                            "data": [
+                                {"type": "People", "id": "9"},
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+
+        resources = RemoteResourceListWrapper(data['data'])
+
+        self.assertEqual(resources[0].authors.links.self, '/articles/1/relationships/authors')
+        self.assertEqual(resources[0].authors.links.related, '/articles/1/authors')
+
 
 @mock.patch('zc_common.remote_resource.request.requests')
 @mock.patch('zc_common.remote_resource.request.zc_settings')

--- a/zc_common/remote_resource/request.py
+++ b/zc_common/remote_resource/request.py
@@ -43,11 +43,11 @@ class RemoteResourceWrapper(object):
         self.create_properties_from_data()
 
     def create_properties_from_data(self):
-        if 'id' in self.data:
-            setattr(self, 'id', self.data.get('id'))
+        accepted_keys = ('id', 'type', 'self', 'related')
 
-        if 'type' in self.data:
-            setattr(self, 'type', self.data.get('type'))
+        for key in self.data.keys():
+            if key in accepted_keys:
+                setattr(self, key, self.data.get(key))
 
         if 'attributes' in self.data:
             attributes = self.data['attributes']
@@ -62,6 +62,10 @@ class RemoteResourceWrapper(object):
                     setattr(self, underscore(key), RemoteResourceListWrapper(relationships[key]['data']))
                 else:
                     setattr(self, underscore(key), RemoteResourceWrapper(relationships[key]['data']))
+
+                if 'links' in relationships[key]:
+                    setattr(getattr(self, underscore(key)), 'links',
+                            RemoteResourceWrapper(relationships[key]['links']))
 
 
 class RemoteResourceListWrapper(list):


### PR DESCRIPTION
Unless we have a reason to omit certain keys/attributes from the `RemoteResourceWrapper`, I think `.create_properties_from_data()` can be re-written to just walk down the json data structure and recursively `setattr()` each object, instead of handling specific keys and cases. Maybe something to revisit after day 1?