### PR TITLE
Ensure remote resource ID is always a string

### DIFF
--- a/zc_common/remote_resource/models.py
+++ b/zc_common/remote_resource/models.py
@@ -4,9 +4,10 @@ from django.db import models
 
 
 class RemoteResource(object):
+
     def __init__(self, type_name, pk):
-        self.type = type_name
-        self.id = pk
+        self.type = str(type_name)
+        self.id = str(pk)
 
 
 class RemoteForeignKey(models.CharField):


### PR DESCRIPTION
This will resolve the bug when we had the user id from the request being a string and the user id from the db an int.

The bug is in the method `from_db_value`:
```
def from_db_value(self, value, expression, connection, context):
        return RemoteResource(self.type, value)
```

It reads the value from the db which is a integer field. Therefore, the value will be an integer, which is initialized in the `RemoteResource` as int. To fix this, we always cast the value as a string.
