### PR TITLE
Theo/update permission mixin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.2.3',
+    version='0.2.4',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.2.3',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.2.4',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/jwt_auth/tests.py
+++ b/zc_common/jwt_auth/tests.py
@@ -123,7 +123,7 @@ class PermissionTestMixin(object):
         attrs = [attr for attr in itertools.ifilter(lambda x: x.startswith('test_'), dir(self))]
         all_roles = [USER_ROLES, STAFF_ROLES, ANONYMOUS_ROLES, SERVICE_ROLES]
         actions = {'delete': ['DELETE'], 'read': ['GET'], 'write': ['PUT', 'PATCH', 'POST']}
-        extra_actions = {'create': ['POST'], 'update': ['PUT', 'PATCH'],}
+        extra_actions = {'create': ['POST'], 'update': ['PUT', 'PATCH']}
         forbidden_actions = set()
         allowed_actions = set()
 


### PR DESCRIPTION
For child classes of `BasePermission`, they was no way to test for actions/permissions that were not overridden. I updated `PermissionTestMixin` to automatically test for this particular case.