### PR TITLE
Add resource_type to RemoteResourceField metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.7',
+    version='0.3.8b1',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.7',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.8b1',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.9b2',
+    version='0.3.9b3',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.9b2',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.9b3',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.8b1',
+    version='0.3.8',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.9b3',
+    version='0.3.9',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.9b3',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.9',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.8',
+    version='0.3.9b1',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.8b1',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.9b1',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.9b1',
+    version='0.3.9b2',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.9b1',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.9b2',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/tests/jwt_auth/test_utils.py
+++ b/tests/jwt_auth/test_utils.py
@@ -10,7 +10,7 @@ class UtilsTest(TestCase):
         self.user = User(id='123456')
 
     def test_jwt_payload_handler__have_required_keys(self):
-        payload = jwt_payload_handler(user)
+        payload = jwt_payload_handler(self.user)
 
         self.assertIn('id', payload)
         self.assertIn('roles', payload)

--- a/tests/remote_resource/test_models.py
+++ b/tests/remote_resource/test_models.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+from django.db import models
+
+from zc_common.remote_resource.models import GenericRemoteForeignKey, RemoteResource
+
+
+class FKModel(models.Model):
+    resource_id = models.TextField(blank=True)
+    resource_type = models.TextField(blank=True)
+    owner = GenericRemoteForeignKey(resource_types=['User', 'Company'])
+
+    class Meta:
+        app_label = 'tests'
+
+
+class TestGenericRemoteForeignKey(TestCase):
+    def test_accepts_only_remote_resource(self):
+        model = FKModel()
+        with self.assertRaises(ValueError):
+            model.owner = 1
+
+        model.owner = RemoteResource('User', '1')
+
+    def test_fills_sub_fields(self):
+        model = FKModel()
+
+        resource_type = 'User'
+        resource_id = '1'
+
+        model.owner = RemoteResource(resource_type, resource_id)
+
+        self.assertEqual(model.resource_type, resource_type)
+        self.assertEqual(model.resource_id, resource_id)
+
+    def test_returns_remote_resource(self):
+        model = FKModel()
+        model.resource_type = 'User'
+        model.resource_id = '1'
+
+        self.assertTrue(isinstance(model.owner, RemoteResource))
+
+    def test_accepts_only_acceptable_types(self):
+        model = FKModel()
+        with self.assertRaises(ValueError):
+            model.owner = RemoteResource('Thing', '1')

--- a/zc_common/remote_resource/metadata.py
+++ b/zc_common/remote_resource/metadata.py
@@ -1,0 +1,28 @@
+from django.db.models.fields import related
+from rest_framework.utils.field_mapping import ClassLookupDict
+from rest_framework_json_api.metadata import JSONAPIMetadata
+
+from zc_common.remote_resource.models import GenericRemoteForeignKey
+from zc_common.remote_resource.relations import RemoteResourceField
+
+
+class RelationshipMetadata(JSONAPIMetadata):
+    relation_type_lookup = ClassLookupDict({
+        related.ManyToManyDescriptor: 'ManyToMany',
+        related.ReverseManyToOneDescriptor: 'OneToMany',
+        related.ForwardManyToOneDescriptor: 'ManyToOne',
+        RemoteResourceField: 'ManyToOne',
+        GenericRemoteForeignKey: 'ManyToOne'
+    })
+
+    def get_field_info(self, field):
+        field_info = super(RelationshipMetadata, self).get_field_info(field)
+        if isinstance(field, RemoteResourceField):
+            model_class = getattr(field.parent.Meta, 'model')
+            model_field = getattr(model_class, field.field_name)
+            if hasattr(model_field, 'type'):
+                field_info['relationship_resource'] = model_field.type
+            else:
+                # Generic FKs have no resource type
+                field_info['relationship_resource'] = None
+        return field_info

--- a/zc_common/remote_resource/metadata.py
+++ b/zc_common/remote_resource/metadata.py
@@ -1,6 +1,9 @@
 from django.db.models.fields import related
+from rest_framework.relations import ManyRelatedField
 from rest_framework.utils.field_mapping import ClassLookupDict
 from rest_framework_json_api.metadata import JSONAPIMetadata
+from rest_framework_json_api.utils import get_related_resource_type
+
 from zc_common.remote_resource.relations import RemoteResourceField
 from zc_common.remote_resource.models import GenericRemoteForeignKey, RemoteForeignKey
 
@@ -16,12 +19,17 @@ class RelationshipMetadata(JSONAPIMetadata):
 
     def get_field_info(self, field):
         field_info = super(RelationshipMetadata, self).get_field_info(field)
-        if isinstance(field, RemoteResourceField):
-            model_class = getattr(field.parent.Meta, 'model')
-            model_field = getattr(model_class, field.field_name)
-            if hasattr(model_field, 'type'):
-                field_info['relationship_resource'] = model_field.type
-            else:
-                # Generic FKs have no resource type
-                field_info['relationship_resource'] = None
+        if isinstance(field, RemoteResourceField) or isinstance(field, ManyRelatedField):
+            model_class = field.parent.Meta.model
+            model_field = getattr(model_class, field.source)
+
+            field_info['relationship_type'] = self.relation_type_lookup[model_field]
+            field_info['relationship_resource'] = get_related_resource_type(field)
+
+            if field_info['relationship_resource'] == 'RemoteResource':
+                if hasattr(model_field, 'type'):
+                    field_info['relationship_resource'] = model_field.type
+                else:
+                    # Generic FKs have no resource type
+                    field_info['relationship_resource'] = None
         return field_info

--- a/zc_common/remote_resource/metadata.py
+++ b/zc_common/remote_resource/metadata.py
@@ -27,9 +27,5 @@ class RelationshipMetadata(JSONAPIMetadata):
             field_info['relationship_resource'] = get_related_resource_type(field)
 
             if field_info['relationship_resource'] == 'RemoteResource':
-                if hasattr(model_field, 'type'):
-                    field_info['relationship_resource'] = model_field.type
-                else:
-                    # Generic FKs have no resource type
-                    field_info['relationship_resource'] = None
+                field_info['relationship_resource'] = model_field.type
         return field_info

--- a/zc_common/remote_resource/metadata.py
+++ b/zc_common/remote_resource/metadata.py
@@ -1,9 +1,8 @@
 from django.db.models.fields import related
 from rest_framework.utils.field_mapping import ClassLookupDict
 from rest_framework_json_api.metadata import JSONAPIMetadata
-
-from zc_common.remote_resource.models import GenericRemoteForeignKey
 from zc_common.remote_resource.relations import RemoteResourceField
+from zc_common.remote_resource.models import GenericRemoteForeignKey, RemoteForeignKey
 
 
 class RelationshipMetadata(JSONAPIMetadata):
@@ -11,7 +10,7 @@ class RelationshipMetadata(JSONAPIMetadata):
         related.ManyToManyDescriptor: 'ManyToMany',
         related.ReverseManyToOneDescriptor: 'OneToMany',
         related.ForwardManyToOneDescriptor: 'ManyToOne',
-        RemoteResourceField: 'ManyToOne',
+        RemoteForeignKey: 'ManyToOne',
         GenericRemoteForeignKey: 'ManyToOne'
     })
 

--- a/zc_common/remote_resource/models.py
+++ b/zc_common/remote_resource/models.py
@@ -93,7 +93,11 @@ class GenericRemoteForeignKey(object):
     related_model = None
     remote_field = None
 
-    def __init__(self, rt_field='resource_type', id_field='resource_id'):
+    def __init__(self, resource_types=None, rt_field='resource_type', id_field='resource_id'):
+        if resource_types is None:
+            raise TypeError('resource_types cannot be None')
+        self.resource_types = resource_types
+        self.type = resource_types  # For metadata class
         self.rt_field = rt_field
         self.id_field = id_field
         self.editable = False
@@ -153,6 +157,10 @@ class GenericRemoteForeignKey(object):
             if not isinstance(value, RemoteResource):
                 raise ValueError(
                     'GenericRemoteForeignKey only accepts RemoteResource objects as values'
+                )
+            if value.type not in self.resource_types:
+                raise ValueError(
+                    'Value must be of type {}, got {}'.format(self.resource_types, value.type)
                 )
             rt = value.type
             pk = value.id

--- a/zc_common/remote_resource/models.py
+++ b/zc_common/remote_resource/models.py
@@ -13,6 +13,14 @@ class RemoteResource(object):
 
 
 class RemoteForeignKey(models.CharField):
+    is_relation = True
+    many_to_many = False
+    many_to_one = True
+    one_to_many = False
+    one_to_one = False
+    related_model = None
+    remote_field = None
+
     description = "A foreign key pointing to an external resource"
 
     def __init__(self, type_name, *args, **kwargs):
@@ -52,6 +60,13 @@ class RemoteForeignKey(models.CharField):
         del kwargs['max_length']
 
         return name, path, args, kwargs
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        self.name = name
+        self.model = cls
+        cls._meta.add_field(self, virtual=True)
+
+        setattr(cls, name, self)
 
 
 class GenericRemoteForeignKey(object):

--- a/zc_common/remote_resource/models.py
+++ b/zc_common/remote_resource/models.py
@@ -62,6 +62,7 @@ class RemoteForeignKey(models.CharField):
         return name, path, args, kwargs
 
     def contribute_to_class(self, cls, name, **kwargs):
+        self.set_attributes_from_name(name)
         self.name = name
         self.model = cls
         cls._meta.add_field(self, virtual=True)

--- a/zc_common/remote_resource/models.py
+++ b/zc_common/remote_resource/models.py
@@ -65,7 +65,7 @@ class RemoteForeignKey(models.CharField):
         self.set_attributes_from_name(name)
         self.name = name
         self.model = cls
-        cls._meta.add_field(self, virtual=True)
+        cls._meta.add_field(self)
 
         setattr(cls, name, self)
 


### PR DESCRIPTION
Deployment:
1. Push new version of zc_common containing this
2. Update each service with the new version (resolve version conflicts)
3. Set the `DEFAULT_METADATA_CLASS` in rest framework settings to use this one

This won't be done until every service has been updated.


Comparison between the old response and what it should look like:
![screen shot 2016-11-10 at 2 38 13 pm](https://cloud.githubusercontent.com/assets/1244123/20197276/6b186cf0-a753-11e6-8935-b1ff38bf49ed.png)

## PRs

PRs for testing have been opened in all service repos, with branch `birkholz/remote_relationship`

* https://github.com/ZeroCater/mp-users/pull/87
* https://github.com/ZeroCater/mp-vendor-services/pull/155
* https://github.com/ZeroCater/mp-geolocation/pull/59
* https://github.com/ZeroCater/scheduler/pull/32
* https://github.com/ZeroCater/mp-slots-and-orders/pull/179

* And the associated IT change: https://github.com/ZeroCater/mp-internal-tools/pull/123