### PR TITLE
Handle empty plaintext and/or html body correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.2.7',
+    version='0.2.8',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.2.7',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.2.8',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/email.py
+++ b/zc_common/email.py
@@ -5,7 +5,6 @@ import uuid
 import boto
 from boto.s3.key import Key
 from django.conf import settings
-from raven.contrib.django.raven_compat.models import client
 from zc_common.events.emit import emit_microservice_event
 
 
@@ -73,10 +72,15 @@ def send_email(from_email=None, to=None, cc=None, bcc=None, reply_to=None,
         with attachments {} and files {}'''
         logger.info(msg.format(email_uuid, to, from_email, attachments, files))
 
-    html_body_key = generate_s3_content_key(s3_folder_name, 'html')
-    upload_string_to_s3(bucket, html_body_key, html_body)
-    plaintext_body_key = generate_s3_content_key(s3_folder_name, 'plaintext')
-    upload_string_to_s3(bucket, plaintext_body_key, plaintext_body)
+    html_body_key = None
+    if html_body:
+        html_body_key = generate_s3_content_key(s3_folder_name, 'html')
+        upload_string_to_s3(bucket, html_body_key, html_body)
+
+    plaintext_body_key = None
+    if plaintext_body:
+        plaintext_body_key = generate_s3_content_key(s3_folder_name, 'plaintext')
+        upload_string_to_s3(bucket, plaintext_body_key, plaintext_body)
 
     attachments_keys = []
     if attachments:


### PR DESCRIPTION
Part of #70.

There was a bug where even if `plaintext_body` and/or `html_body` content is empty, the send_email event argument `plaintext_body_key` and `html_body_key` is assigned even though no content is uploaded to S3. The matching `mp-email` `send_email()` function uses these keys to fetch content from S3, and since there is nothing uploaded there, throws an error.

With this change, `mp-email.send_email()` will handle either or both `plaintext_body` and `html_body` being empty correctly.
