### PR TITLE
Add databaseless test runner

### DIFF
--- a/zc_common/databaseless_test_runner.py
+++ b/zc_common/databaseless_test_runner.py
@@ -1,0 +1,13 @@
+from django.test.runner import DiscoverRunner
+
+
+class DatabaselessTestRunner(DiscoverRunner):
+    """A test suite runner that does not set up and tear down a database."""
+
+    def setup_databases(self):
+        """Overrides DjangoTestSuiteRunner"""
+        pass
+
+    def teardown_databases(self, *args):
+        """Overrides DjangoTestSuiteRunner"""
+        pass


### PR DESCRIPTION
Add a `DatabaselessTestRunner` class that will allow us to run test suites of Django test cases for microservices that do not have a database.

To use, add
```
TEST_RUNNER = 'zc_common.databaseless_test_runner.DatabaselessTestRunner'
```
to `settings.py`.