### PR TITLE
Add new PKField

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.6',
+    version='0.3.7',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.6',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.7',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/fields.py
+++ b/zc_common/fields.py
@@ -1,12 +1,17 @@
 from __future__ import unicode_literals
 
 import re
+import uuid
 
 from django.db import models
 from django.core.validators import RegexValidator
 
 
 US_PHONE_FORMAT = r'^(\+1\s?)?\(?(\d{3})\)?[\s-]?(\d{3})[\s-]?(\d{4})$'
+
+
+def numeric_uuid_generator():
+    return str(uuid.uuid4().int)[:10]
 
 
 class PhoneNumberField(models.CharField):
@@ -33,3 +38,18 @@ class PhoneNumberField(models.CharField):
             return value
 
         return "({}) {}-{}".format(r.group(2), r.group(3), r.group(4))
+
+
+class PKField(models.CharField):
+    description = "A primary key field that defaults to a 10 digit random int"
+
+    def __init__(self, *args, **kwargs):
+        kwargs['primary_key'] = True
+
+        if 'default' not in kwargs:
+            kwargs['default'] = numeric_uuid_generator
+
+        if 'max_length' not in kwargs:
+            kwargs['max_length'] = 50
+
+        super(PKField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Introduces a new `PKField` Django model field that inherits from `CharField` which can be used as a drop-in primary key field like: `id = PKField()`. The field will automatically default the value to be a random 10 digit string.