### PR TITLE
Fix model_field AttributeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.11b1',
+    version='0.3.11',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.3.10',
+    version='0.3.11b1',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.10',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.3.11',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/remote_resource/metadata.py
+++ b/zc_common/remote_resource/metadata.py
@@ -27,7 +27,7 @@ class RelationshipMetadata(JSONAPIMetadata):
             model_class = field.parent.Meta.model
             model_field = getattr(model_class, field.source)
 
-            if isinstance(model_field.field, OneToOneField):
+            if hasattr(model_field, 'field') and isinstance(model_field.field, OneToOneField):
                 # ForwardManyToOneDescriptor is used for OneToOneField also, so we have to override
                 model_field = model_field.field
 


### PR DESCRIPTION
`model_field.field` isn't assigned when `model_field` is a reverse relationship. Reverse relationships are less common, and so this bug wasn't caught when testing version 0.3.10 because the serializer I was testing against didn't have a reverse relationship.

This PR has been tested with forwards, reverse, and remote relations.