### PR TITLE
Default tests to use model-defined JSONAPIMeta resource name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.4.3',
+    version='0.4.4',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.3',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.4',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/remote_resource/parsers.py
+++ b/zc_common/remote_resource/parsers.py
@@ -64,7 +64,10 @@ class JSONParser(parsers.JSONParser):
         else:
             # Handles requests created by Django's test client, which is missing the raw_body attribute set in
             # the Django request-like object initialized by our zc_event event client
-            result = ujson.loads(stream.body)
+            try:
+                result = ujson.loads(stream.body)
+            except ValueError:
+                result = {}
 
         data = result.get('data')
 

--- a/zc_common/remote_resource/tests.py
+++ b/zc_common/remote_resource/tests.py
@@ -95,9 +95,12 @@ class ResponseTestCase(APITestCase):
                 self.assertEqual(data_object['id'], str(instance_object.id))
 
                 try:
-                    instance_type = instance_object.type
+                    instance_type = instance_object.__class__.JSONAPIMeta.resource_name
                 except AttributeError:
-                    instance_type = instance_object.__class__.__name__
+                    try:
+                        instance_type = instance_object.type
+                    except AttributeError:
+                        instance_type = instance_object.__class__.__name__
 
                 self.assertEqual(data_object['type'], instance_type)
 


### PR DESCRIPTION
Since we have a `Category` resource in `mp-vendor-services` and a `Category` resource in `snacks-prototype`, we are renaming the `snacks-prototype` resource to `SnackCategory`.

This requires us to look up the resource name defined in the model's `JSONAPIMeta` class instead of the classname itself.