### PR TITLE
Improve filter to handle lookup filters (such as __gt, __lt)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.4.5',
+    version='0.4.6',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.5',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.6',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/remote_resource/filters.py
+++ b/zc_common/remote_resource/filters.py
@@ -3,6 +3,7 @@ from distutils.util import strtobool
 
 from django.db.models import BooleanField, FieldDoesNotExist
 from django.db.models.fields.related import ManyToManyField
+from django_filters import filters
 from django.utils import six
 
 # DjangoFilterBackend was moved to django-filter and deprecated/moved from DRF in version 3.6
@@ -22,18 +23,19 @@ class JSONAPIFilterBackend(DjangoFilterBackend):
         for param, value in six.iteritems(request.query_params):
             match = re.search(r'^filter\[(\w+)\]$', param)
             if match:
-                field_name = match.group(1)
-                try:
-                    name, extra = field_name.split('__')
-                except ValueError:
-                    name = field_name
-                    extra = None
-                if name not in view.filter_fields.keys():
+                filter_string = match.group(1)
+                field_name = filter_string.split('__').pop(0)
+
+                if field_name not in view.filter_fields.keys():
                     return queryset.none()
-                if len(field_name) > 1 and field_name[:2] == 'id':
-                    query_params['{0}__{1}'.format(primary_key, extra)] = value
-                if hasattr(queryset.model, field_name)\
-                        and isinstance(getattr(queryset.model, field_name).field, ManyToManyField):
+
+                if len(filter_string) > 1 and field_name == 'id':
+                    filter_string_parts = filter_string.split('__')
+                    filter_string_parts[0] = primary_key
+                    query_params['__'.join(filter_string_parts)] = value
+
+                if hasattr(queryset.model, filter_string)\
+                   and isinstance(getattr(queryset.model, filter_string).field, ManyToManyField):
                     value = value.split(',')
 
                 # Allow 'true' or 'false' as values for boolean fields
@@ -43,7 +45,7 @@ class JSONAPIFilterBackend(DjangoFilterBackend):
                 except FieldDoesNotExist:
                     pass
 
-                query_params[field_name] = value
+                query_params[filter_string] = value
 
         if filter_class:
             return filter_class(query_params, queryset=queryset).qs

--- a/zc_common/remote_resource/filters.py
+++ b/zc_common/remote_resource/filters.py
@@ -3,7 +3,6 @@ from distutils.util import strtobool
 
 from django.db.models import BooleanField, FieldDoesNotExist
 from django.db.models.fields.related import ManyToManyField
-from django_filters import filters
 from django.utils import six
 
 # DjangoFilterBackend was moved to django-filter and deprecated/moved from DRF in version 3.6


### PR DESCRIPTION
Previously, we only handled `filter[field_name]=` and `filter[field_name__in]` look up filters. This PR attempts to extend functionality to include other lookup expressions (that `django-filters` already supports, since they're essentially just passing them in as queryset filters.

Tests for the filters can be found here: https://github.com/ZeroCater/snacks-prototype/pull/544/files#diff-7f40c5959d7552d8ec51e7ba876c04f0R116
though there should ideally be unittests in this repo as well.

Also I found the original variable names to be misleading so I renamed them.