### PR TITLE
Dropping companies from JWT payload

### DIFF
--- a/tests/jwt_auth/test_utils.py
+++ b/tests/jwt_auth/test_utils.py
@@ -14,4 +14,3 @@ class UtilsTest(TestCase):
 
         self.assertIn('id', payload)
         self.assertIn('roles', payload)
-        self.assertIn('companies', payload)

--- a/zc_common/jwt_auth/utils.py
+++ b/zc_common/jwt_auth/utils.py
@@ -16,7 +16,6 @@ def jwt_payload_handler(user):
     payload = {
         'id': encoding.force_text(user.pk),
         'roles': user.get_roles(),
-        'companies': user.get_company_permissions(),
     }
 
     return payload


### PR DESCRIPTION
As we are cleaning up `companies` from `mp-users`, there are other places affected that used to rely on this. This shared library is actually where the JWT payload is originated, including the companies that are related to each user account in `mp-users`, which will be removed in this PR.