### PR TITLE
Improve error message when unexpected request.data encountered during parsing

### DIFF
--- a/zc_common/remote_resource/parsers.py
+++ b/zc_common/remote_resource/parsers.py
@@ -69,6 +69,9 @@ class JSONParser(parsers.JSONParser):
             except ValueError:
                 result = {}
 
+        if not isinstance(result, dict):
+            raise ParseError('Received data is not a valid JSON Object')
+
         data = result.get('data')
 
         if data:


### PR DESCRIPTION


```
snacks-prototype-worker_1     | [2018-04-30 16:08:24,084: ERROR/MainProcess] Task microservice.event[7a57a62d-b530-41f5-b58d-b5fecb01af18] raised unexpected: TypeError('Parser must be a string or character stream, not NoneType',)
snacks-prototype-worker_1     | Traceback (most recent call last):
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 240, in trace_task
snacks-prototype-worker_1     |     R = retval = fun(*args, **kwargs)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 438, in __protected_call__
snacks-prototype-worker_1     |     return self.run(*args, **kwargs)
snacks-prototype-worker_1     |   File "/code/prototype/tasks/microservice_events_listener.py", line 19, in microservice_event
snacks-prototype-worker_1     |     'MICROSERVICE_EVENT::IGNORED: Received [{}:{}] event for object ({}:{}) and user {}'.format(
snacks-prototype-worker_1     |   File "/code/prototype/tasks/microservice_events.py", line 121, in snack_company_stats_request
snacks-prototype-worker_1     |   File "/pip-install/zc-events/zc_events/client.py", line 386, in handle_request_event
snacks-prototype-worker_1     |     result = handler(request, **handler_kwargs)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
snacks-prototype-worker_1     |     return view_func(*args, **kwargs)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/django/views/generic/base.py", line 68, in view
snacks-prototype-worker_1     |     return self.dispatch(request, *args, **kwargs)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 494, in dispatch
snacks-prototype-worker_1     |     response = self.handle_exception(exc)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 454, in handle_exception
snacks-prototype-worker_1     |     self.raise_uncaught_exception(exc)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 491, in dispatch
snacks-prototype-worker_1     |     response = handler(request, *args, **kwargs)
snacks-prototype-worker_1     |   File "/code/locations/views.py", line 85, in post
snacks-prototype-worker_1     |     start_date = parser.parse(data.get('start_date')).replace(tzinfo=pacific_timezone)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/dateutil/parser.py", line 1182, in parse
snacks-prototype-worker_1     |     return DEFAULTPARSER.parse(timestr, **kwargs)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/dateutil/parser.py", line 556, in parse
snacks-prototype-worker_1     |     res, skipped_tokens = self._parse(timestr, **kwargs)
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/dateutil/parser.py", line 675, in _parse
snacks-prototype-worker_1     |     l = _timelex.split(timestr)         # Splits the timestr into tokens
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/dateutil/parser.py", line 192, in split
snacks-prototype-worker_1     |     return list(cls(s))
snacks-prototype-worker_1     |   File "/usr/local/lib/python3.6/site-packages/dateutil/parser.py", line 61, in __init__
snacks-prototype-worker_1     |     '{itype}'.format(itype=instream.__class__.__name__))
snacks-prototype-worker_1     | TypeError: Parser must be a string or character stream, not NoneType
```