### PR TITLE
Dropping get_company_permissions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.4.8',
+    version='0.4.9',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.8',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.9',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/jwt_auth/authentication.py
+++ b/zc_common/jwt_auth/authentication.py
@@ -32,13 +32,6 @@ class User(object):
         """
         return self.roles
 
-    def get_company_permissions(self):
-        """
-        For testing purposes only. Emulates `get_company_permissions` in
-        https://github.com/ZeroCater/mp-users/blob/master/users/models.py
-        """
-        return self.company_permissions
-
 
 class JWTAuthentication(BaseAuthentication):
     """


### PR DESCRIPTION
Resuming our `companies` removal efforts from our main _users_ app, permissions for given companies were returned using a helper function that we are dropping now.