### PR TITLE
Adds decimal_places attribute to OPTIONS response

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.4.10',
+    version='0.4.11',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.10',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.11',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/remote_resource/metadata.py
+++ b/zc_common/remote_resource/metadata.py
@@ -1,6 +1,7 @@
 from django.db.models import OneToOneField
 from django.db.models.fields import related
 from rest_framework.relations import ManyRelatedField
+from rest_framework.serializers import DecimalField
 from rest_framework.utils.field_mapping import ClassLookupDict
 from rest_framework_json_api.metadata import JSONAPIMetadata
 from rest_framework_json_api.relations import ResourceRelatedField
@@ -36,4 +37,7 @@ class RelationshipMetadata(JSONAPIMetadata):
 
             if field_info['relationship_resource'] == 'RemoteResource':
                 field_info['relationship_resource'] = model_field.type
+
+        if isinstance(field, DecimalField):
+            field_info['decimal_places'] = getattr(field, 'decimal_places', 2)
         return field_info


### PR DESCRIPTION
These are the default attributes included per-field in DRF's `OPTIONS` response:
https://github.com/encode/django-rest-framework/blob/master/rest_framework/metadata.py#L126

For serializer fields of type `DecimalField`, the `OPTIONS` response won't include the `decimal_places` attribute. This would be useful metadata for the field, and necessary for proper validation in internal tools.

```
{'data': {'actions': {'POST': {
                               'access_notes': {'label': 'Access notes',
                                                'read_only': False,
                                                'required': False,
                                                'type': 'String',
                                                'write_only': False},
                               ....(truncated).....
                               'tax_rate': {'decimal_places': 3,
                                            'help_text': 'The sales tax rate '
                                                         'for this location as '
                                                         'a percentage (ie '
                                                         "'8.250' for "
                                                         '8.25%).You can look '
                                                         'this up <a '
                                                         "href='http://www.boe.ca.gov/cgi-bin/rates.cgi'>using "
                                                         'this tool</a>.',
                                            'label': 'Tax rate',
                                            'read_only': False,
                                            'required': True,
                                            'type': 'Decimal',
                                            'write_only': False}}},
          'allowed_methods': ['GET', 'POST', 'HEAD', 'OPTIONS'],
          'description': '',
          'name': 'Address',
          'parses': ['application/vnd.api+json'],
          'renders': ['application/vnd.api+json']}}
```