### PR TITLE
SP-368: Overrides behavior to limit foreign key filter choices

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.4.15',
+    version='0.4.16',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.15',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.16',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[


### PR DESCRIPTION
## Summary

By default, `django_filters` limits foreign key filter choices to the queryset specified by `Model._default_manager`.
https://github.com/carltongibson/django-filter/blob/1.0.4/django_filters/compat.py#L52-L56

We want to open that queryset to objects specified by `Model._base_manager`. This seems more in line with the purpose of `_base_manager` vs `_default_manager` anyway.
https://docs.djangoproject.com/en/2.2/topics/db/managers/#base-managers

The specific use case is that in snacks, we have a limited manager set as the default, filtering out churned objects, prospect objects, etc. We have additional managers that allow us to interact with those filtered out objects, e.g. `Company.prospect_objects.all()` allows us to grab prospect objects. From the API, we need to be able to filter on related foreign keys, but when we try to, we're stopped by `django_filters` grabbing valid objects via default manager, which returns the set of non-prospect objects, causing the code to mark the filter as invalid.

By opening up the queryset of valid objects to the default manager, we pull the full set of possible related objects.