### PR TITLE
SP-377: Updates to support Django 2.2, DRF 3.10, DRFJsonApi 3.0, django_filters 1.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ def get_packages(package):
 
 setup(
     name='zc_common',
-    version='0.4.16',
+    version='0.4.17',
     description="Shared code for ZeroCater microservices",
     long_description='',
     keywords='zerocater python util',
     author='ZeroCater',
     author_email='tech@zerocater.com',
     url='https://github.com/ZeroCater/zc_common',
-    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.16',
+    download_url='https://github.com/ZeroCater/zc_common/tarball/0.4.17',
     license='MIT',
     packages=get_packages('zc_common'),
     classifiers=[

--- a/zc_common/remote_resource/filters.py
+++ b/zc_common/remote_resource/filters.py
@@ -12,16 +12,29 @@ from django.utils import six
 try:
     from rest_framework.filters import DjangoFilterBackend, Filter
     from rest_framework import filterset
-    from rest_framework.compat import get_related_model as remote_model
 except ImportError:
-    from django_filters.compat import remote_model
     from django_filters.rest_framework import DjangoFilterBackend, filterset
     from django_filters.rest_framework.filters import Filter
     from django_filters.filters import ModelChoiceFilter
 
+# remote_model() was removed from django_filters in 2.0
+try:
+    try:
+        from rest_framework.compat import get_related_model as remote_model
+    except ImportError:
+        from django_filters.compat import remote_model
+except:
+    pass
+
+
 
 def remote_queryset(field):
-    model = remote_model(field)
+    # remote_model() was removed from django_filters in 2.0
+    try:
+        model = remote_model(field)
+    except:
+        model = field.remote_field.model
+
     limit_choices_to = field.get_limit_choices_to()
     return model._base_manager.complex_filter(limit_choices_to)
 

--- a/zc_common/remote_resource/filters.py
+++ b/zc_common/remote_resource/filters.py
@@ -27,7 +27,6 @@ except:
     pass
 
 
-
 def remote_queryset(field):
     # remote_model() was removed from django_filters in 2.0
     try:

--- a/zc_common/remote_resource/parsers.py
+++ b/zc_common/remote_resource/parsers.py
@@ -8,6 +8,14 @@ from rest_framework.exceptions import ParseError
 from rest_framework_json_api import utils, renderers, exceptions
 
 
+# `format_keys()` was replaced with `format_field_names()` from rest_framework_json_api in 3.0.0
+def key_formatter():
+    try:
+        return utils.format_field_names
+    except ImportError:
+        return utils.format_keys
+
+
 class JSONParser(parsers.JSONParser):
     """
     A JSON API client will send a payload that looks like this:
@@ -30,11 +38,11 @@ class JSONParser(parsers.JSONParser):
 
     @staticmethod
     def parse_attributes(data):
-        return utils.format_keys(data.get('attributes'), 'underscore') if data.get('attributes') else dict()
+        return key_formatter()(data.get('attributes'), 'underscore') if data.get('attributes') else dict()
 
     @staticmethod
     def parse_relationships(data):
-        relationships = (utils.format_keys(data.get('relationships'), 'underscore')
+        relationships = (key_formatter()(data.get('relationships'), 'underscore')
                          if data.get('relationships') else dict())
 
         # Parse the relationships

--- a/zc_common/remote_resource/parsers.py
+++ b/zc_common/remote_resource/parsers.py
@@ -7,11 +7,13 @@ from rest_framework import parsers
 from rest_framework.exceptions import ParseError
 from rest_framework_json_api import utils, renderers, exceptions
 
+from zc_common.remote_resource import utils as zc_common_utils
+
 
 # `format_keys()` was replaced with `format_field_names()` from rest_framework_json_api in 3.0.0
 def key_formatter():
     try:
-        return utils.format_field_names
+        return zc_common_utils.format_keys
     except AttributeError:
         return utils.format_keys
 

--- a/zc_common/remote_resource/parsers.py
+++ b/zc_common/remote_resource/parsers.py
@@ -12,7 +12,7 @@ from rest_framework_json_api import utils, renderers, exceptions
 def key_formatter():
     try:
         return utils.format_field_names
-    except ImportError:
+    except AttributeError:
         return utils.format_keys
 
 

--- a/zc_common/remote_resource/renderers.py
+++ b/zc_common/remote_resource/renderers.py
@@ -25,6 +25,14 @@ core_module = __import__(core_module_name)
 event_client = core_module.event_client
 
 
+# `format_keys()` was replaced with `format_field_names()` from rest_framework_json_api in 3.0.0
+def key_formatter():
+    try:
+        return utils.format_field_names
+    except AttributeError:
+        return utils.format_keys
+
+
 class RemoteResourceIncludeError(Exception):
 
     def __init__(self, field, data=None):
@@ -199,7 +207,7 @@ class JSONRenderer(renderers.JSONRenderer):
                         )
                     )
 
-        return utils.format_keys(included_data)
+        return key_formatter()(included_data)
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
 
@@ -266,7 +274,7 @@ class JSONRenderer(renderers.JSONRenderer):
                             fields, resource, resource_instance, resource_name)
                         meta = self.extract_meta(serializer, resource)
                         if meta:
-                            json_resource_obj.update({'meta': utils.format_keys(meta)})
+                            json_resource_obj.update({'meta': key_formatter()(meta)})
                         json_api_data.append(json_resource_obj)
 
                         included = self.extract_included(request, fields, resource,
@@ -280,7 +288,7 @@ class JSONRenderer(renderers.JSONRenderer):
 
                     meta = self.extract_meta(serializer, serializer_data)
                     if meta:
-                        json_api_data.update({'meta': utils.format_keys(meta)})
+                        json_api_data.update({'meta': key_formatter()(meta)})
 
                     included = self.extract_included(request, fields, serializer_data,
                                                      resource_instance, included_resources)

--- a/zc_common/remote_resource/renderers.py
+++ b/zc_common/remote_resource/renderers.py
@@ -316,7 +316,7 @@ class JSONRenderer(renderers.JSONRenderer):
             render_data['included'] = sorted(unique_compound_documents, key=lambda item: (item['type'], item['id']))
 
         if json_api_meta:
-            render_data['meta'] = utils.format_keys(json_api_meta)
+            render_data['meta'] = key_formatter()(json_api_meta)
 
         return super(renderers.JSONRenderer, self).render(
             render_data, accepted_media_type, renderer_context

--- a/zc_common/remote_resource/utils.py
+++ b/zc_common/remote_resource/utils.py
@@ -1,0 +1,36 @@
+from collections import OrderedDict
+
+import inflection
+
+from django.conf import settings
+
+
+def format_keys(obj, format_type=None):
+    if format_type is None:
+        format_type = getattr(settings, 'JSON_API_FORMAT_FIELD_NAMES', False)
+
+    if format_type in ('dasherize', 'camelize', 'underscore', 'capitalize'):
+        if isinstance(obj, dict):
+            formatted = OrderedDict()
+            for key, value in obj.items():
+                if format_type == 'dasherize':
+                    # inflection can't dasherize camelCase
+                    key = inflection.underscore(key)
+                    formatted[inflection.dasherize(key)] \
+                        = format_keys(value, format_type)
+                elif format_type == 'camelize':
+                    formatted[inflection.camelize(key, False)] \
+                        = format_keys(value, format_type)
+                elif format_type == 'capitalize':
+                    formatted[inflection.camelize(key)] \
+                        = format_keys(value, format_type)
+                elif format_type == 'underscore':
+                    formatted[inflection.underscore(key)] \
+                        = format_keys(value, format_type)
+            return formatted
+        if isinstance(obj, list):
+            return [format_keys(item, format_type) for item in obj]
+        else:
+            return obj
+    else:
+        return obj


### PR DESCRIPTION
Combines with:
https://github.com/ZeroCater/snacks-prototype/pull/1394

* Adjusts for removed `remote_model()` function (https://github.com/carltongibson/django-filter/pull/797/files)
* Copies previous drf_json_api `format_keys()` to and overrides `parse_attributes` to call `format_keys()` instead of `format_value()`. Without this, nested keys in the API do not get camelcased, but are underscored instead. `format_keys()` does a recursive conversion of keys, but `format_values()` only handles top level under `attributes`.
* Copies previous drf_json_api metadata `get_serializer_info()` and overrides it to remove `format_value()` on keys. This was a new change, and changes `options` responses to be camelcased rather than underscored. While this might be the "correct" direction to move for jsonapi, incorporating this change would mean changing all of internal tools (which uses `OPTIONS` to build forms) to accommodate the change. Since we are moving away from jsonapi, it is less friction to just keep the old functionality, and leave options responses underscored.