### PR TITLE
DASH-13080 chore: remove ujson upper bound pin for Python 3.11+ compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     install_requires=[
         'python-dateutil>=2.6.1',
-        'ujson>=1.35,<1.36',
+        'ujson>=1.35',
         'PyJWT>=1.6.4',
         'inflection>=0.3.1',
         'pytz>=2014.2',


### PR DESCRIPTION
## Summary
- Removes the `<1.36` upper bound on ujson in `setup.py`, allowing ujson 5.x to be installed
- ujson 1.35 has C extension incompatibilities with Python 3.11+ (`_Buffer_AppendShortHexUnchecked` symbol not found)
- Only `ujson.loads()` and `ujson.dumps()` are used in zc_common, which are stable across all versions

## Test plan
- [ ] Verify zc_common works with ujson 5.x on Python 3.11
- [ ] Verify backward compatibility with ujson 1.35 on Python 3.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)