### PR TITLE
DASH-13080 Support for python/django/celery upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
         'inflection>=0.3.1',
         'pytz>=2014.2',
         'python-dateutil>=2.7.3',
-        'django-filter>=22.1',
-    ]
+    ],
+    extras_require={
+        'filters': ['django-filter>=22.1'],
+    }
 )


### PR DESCRIPTION
Make django-filters an optional dependency to prevent forcing services to upgrade django if they don't require django filters.